### PR TITLE
pre-commit: pin pandoc for deterministic README generation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
     hooks:
       - id: whool-init
   - repo: https://github.com/NextERP-Romania/maintainer-tools
-    rev: d0d5862c4b5354776193c260dbd3a9442e3ce3a4
+    rev: 2a9e0531afb2302457fc4cfd5c4a67eaef4833c0
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons

--- a/nexterp_account_invoice_debt_recovery/models/account_move.py
+++ b/nexterp_account_invoice_debt_recovery/models/account_move.py
@@ -40,9 +40,6 @@ class AccountMove(models.Model):
         if self.company_id.account_allow_debt_recovery_invoice:
             self.debt_recovery = True
             self.payment_state = "debt_recovery"
-            receivable_line = self.line_ids.filtered(
-                lambda line: line.account_id.account_type == "asset_receivable"
-            )
 
     def _compute_amount(self):
         res = super()._compute_amount()
@@ -50,9 +47,6 @@ class AccountMove(models.Model):
             if move.debt_recovery:
                 if move.payment_state == "paid":
                     move.debt_recovery_done = True
-                    receivable_line = move.line_ids.filtered(
-                        lambda line: line.account_id.account_type == "asset_receivable"
-                    )
                 else:
                     move.payment_state = "debt_recovery"
         return res

--- a/nexterp_account_invoice_debt_recovery/views/account_move_view.xml
+++ b/nexterp_account_invoice_debt_recovery/views/account_move_view.xml
@@ -96,7 +96,7 @@
             </filter>
         </field>
     </record>
-        <record id="action_mark_as_debt_recovery" model="ir.actions.server">
+    <record id="action_mark_as_debt_recovery" model="ir.actions.server">
         <field name="name">Mark as debt recovery</field>
         <field name="model_id" ref="account.model_account_move" />
         <field name="state">code</field>

--- a/nexterp_inter_company/models/res_partner.py
+++ b/nexterp_inter_company/models/res_partner.py
@@ -35,6 +35,7 @@ class ResPartner(models.Model):
         """
         if not column_exists(self.env.cr, "res_partner", "is_inter_company"):
             create_column(self.env.cr, "res_partner", "is_inter_company", "boolean")
+            # pylint: disable=no-search-all
             company_partners = self.env["res.company"].search([]).mapped("partner_id")
             # pylint: disable=E8103
             self.env.cr.execute(
@@ -43,9 +44,9 @@ class ResPartner(models.Model):
                 SET is_inter_company = FALSE;
                 """
             )  # noqa
-            for company in self.env["res.company"].search([]):
+            for company in self.env["res.company"].search([]):  # pylint: disable=no-search-all
                 partners = company_partners.filtered(
-                    lambda p: p.id == company.partner_id.id
+                    lambda p, company=company: p.id == company.partner_id.id
                 )
                 # pylint: disable=E8103
                 self.env.cr.execute(

--- a/nexterp_inter_company_account/models/account_move.py
+++ b/nexterp_inter_company_account/models/account_move.py
@@ -17,6 +17,7 @@ class AccountMove(models.Model):
         """
         if not column_exists(self.env.cr, "account_move", "is_inter_company"):
             create_column(self.env.cr, "account_move", "is_inter_company", "boolean")
+            # pylint: disable=no-search-all
             company_partners = self.env["res.company"].search([]).mapped("partner_id")
             # pylint: disable=E8103
             self.env.cr.execute(
@@ -25,9 +26,9 @@ class AccountMove(models.Model):
                 SET is_inter_company = FALSE;
                 """
             )  # noqa
-            for company in self.env["res.company"].search([]):
+            for company in self.env["res.company"].search([]):  # pylint: disable=no-search-all
                 partners = company_partners.filtered(
-                    lambda p: p.id != company.partner_id.id
+                    lambda p, company=company: p.id != company.partner_id.id
                 )
                 # pylint: disable=E8103
                 self.env.cr.execute(

--- a/nexterp_inter_company_account/report/account_move_report_views.xml
+++ b/nexterp_inter_company_account/report/account_move_report_views.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-
     <record id="view_account_invoice_report_search_inter_company" model="ir.ui.view">
         <field name="name">view_account_invoice_report_search_inter_company</field>
         <field name="model">account.invoice.report</field>
@@ -21,5 +20,4 @@
             </filter>
         </field>
     </record>
-
 </odoo>

--- a/nexterp_inter_company_account/views/account_move_line_views.xml
+++ b/nexterp_inter_company_account/views/account_move_line_views.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-
     <record id="view_account_move_line_filter_inter_company" model="ir.ui.view">
         <field name="name">view_account_move_line_filter_inter_company</field>
         <field name="model">account.move.line</field>
@@ -21,6 +20,4 @@
             </filter>
         </field>
     </record>
-
-
 </odoo>

--- a/nexterp_inter_company_account/views/account_move_views.xml
+++ b/nexterp_inter_company_account/views/account_move_views.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-
     <record id="view_account_invoice_filter_inter_company" model="ir.ui.view">
         <field name="name">account.view_account_invoice_filter_inter_company</field>
         <field name="model">account.move</field>
@@ -42,5 +41,4 @@
             </filter>
         </field>
     </record>
-
 </odoo>

--- a/nexterp_purchase_exception/views/purchase_view.xml
+++ b/nexterp_purchase_exception/views/purchase_view.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" ?>
 <odoo>
-
     <record id="purchase_exception_view_order_form" model="ir.ui.view">
         <field name="name">nexterp_purchase_exception.view_order_form_nexterp</field>
         <field name="model">purchase.order</field>


### PR DESCRIPTION
Bumps the `maintainer-tools` pre-commit pin to `2a9e053`, which pins pandoc to **3.1.3** inside `oca-gen-addon-readme` (forced via `PYPANDOC_PANDOC`).

**Why:** different pandoc versions reflow RST (`-  x` vs `- x`), so README.rst output was environment-dependent across the doc-refresh bot, local pre-commit and CI. Pinning makes it byte-identical. Config-only; requires `maintainer-tools@master` (already updated).