### PR TITLE
[FIX] l10n_ro_edi_extension: simplify invoice fetch window and handle malformed SPV XML

### DIFF
--- a/l10n_ro_edi_extension/models/account_move.py
+++ b/l10n_ro_edi_extension/models/account_move.py
@@ -25,13 +25,7 @@ class AccountMove(models.Model):
     @api.model
     def _l10n_ro_edi_fetch_invoices(self):
         """Synchronize bills/invoices from SPV"""
-        nb_days = (
-            self.env["ir.config_parameter"]
-            .sudo()
-            .get_param("l10n_ro_edi_nb_days_to_fetch")
-            or self.env.company.l10n_ro_download_einvoices_days
-            or 1
-        )
+        nb_days = self.env.company.l10n_ro_download_einvoices_days or 1
         _logger.info(
             "Starting synchronization of sent invoices with SPV for the last %s days",
             nb_days,

--- a/l10n_ro_edi_extension/models/res_company.py
+++ b/l10n_ro_edi_extension/models/res_company.py
@@ -15,7 +15,7 @@ class ResCompany(models.Model):
         help="Add users to receive EDI Error messages",
     )
 
-    @api.constrains("l10n_ro_edi_residence", "l10n_ro_download_einvoices_days")
+    @api.constrains("l10n_ro_edi_residence")
     def _check_l10n_ro_edi_residence(self):
         for company in self:
             if company.l10n_ro_edi_residence < 0 or company.l10n_ro_edi_residence > 5:

--- a/l10n_ro_edi_extension/models/utils.py
+++ b/l10n_ro_edi_extension/models/utils.py
@@ -16,6 +16,31 @@ NS_DOWNLOAD = {
 NS_SIGNATURE = {"ns": "http://www.w3.org/2000/09/xmldsig#"}
 
 
+def _safe_xml_fromstring(file_bytes):
+    """Parse XML bytes received from the SPV, working around invoices that
+    incorrectly declare ``xmlns:schemaLocation`` instead of
+    ``xsi:schemaLocation``. lxml treats the former as a namespace
+    declaration and rejects its (space-separated, two-URI) value as an
+    invalid URI, so the whole download fails to parse even though the
+    document is otherwise well-formed."""
+    try:
+        return etree.fromstring(file_bytes)
+    except etree.XMLSyntaxError:
+        if b"xmlns:schemaLocation=" not in file_bytes:
+            raise
+        fixed_bytes = file_bytes.replace(
+            b"xmlns:schemaLocation=", b"xsi:schemaLocation="
+        )
+        if b"xmlns:xsi=" not in fixed_bytes:
+            fixed_bytes = fixed_bytes.replace(
+                b"xsi:schemaLocation=",
+                b'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+                b"xsi:schemaLocation=",
+                1,
+            )
+        return etree.fromstring(fixed_bytes)
+
+
 def make_efactura_request(
     session, company, endpoint, params, data=None
 ) -> dict[str, str | bytes]:
@@ -149,7 +174,7 @@ def _request_ciusro_download_answer(company, key_download, session):
         with zipfile.ZipFile(io.BytesIO(result["content"])) as zip_ref:
             for file in zip_ref.infolist():
                 file_bytes = zip_ref.read(file)
-                root = etree.fromstring(file_bytes)
+                root = _safe_xml_fromstring(file_bytes)
 
                 # Extract the signature
                 if "semnatura" in file.filename:


### PR DESCRIPTION
- Drop ir.config_parameter override for l10n_ro_edi_nb_days_to_fetch; use company field with fallback to 1 day
- Remove unused l10n_ro_download_einvoices_days trigger from residence constrains
- Add _safe_xml_fromstring to work around SPV invoices declaring xmlns:schemaLocation instead of xsi:schemaLocation